### PR TITLE
Replace all occurences of replacement words

### DIFF
--- a/src/lib/placekey.js
+++ b/src/lib/placekey.js
@@ -29,20 +29,38 @@ const TUPLE_LENGTH = 3;
 const PADDING_CHAR = 'a';
 const PADDING_REGEX = /a/g;
 const REPLACEMENT_CHARS = 'eu';
-const REPLACEMENT_MAP = {
-  prn: 'pre',
-  f4nny: 'f4nne',
-  tw4t: 'tw4e',
-  ngr: 'ngu', // 'u' avoids introducing 'gey'
-  dck: 'dce',
-  vjn: 'vju', // 'u' avoids introducing 'jew'
-  fck: 'fce',
-  pns: 'pne',
-  sht: 'she',
-  kkk: 'kke',
-  fgt: 'fgu', // 'u' avoids introducing 'gey'
-  dyk: 'dye',
-  bch: 'bce'
+
+// Two copies of the REPLACEMENT_MAP are here to hold the regular expression objects
+// needed. Both should be in the same order as REPLACEMENT_MAP.
+const REPLACEMENT_MAP_BACKWARD = {
+  prn: /pre/g,
+  f4nny: /f4nne/g,
+  tw4t: /gtw4e/g,
+  ngr: /ngu/g, // 'u' avoids introducing 'gey'
+  dck: /dce/g,
+  vjn: /vju/g, // 'u' avoids introducing 'jew'
+  fck: /fce/g,
+  pns: /pne/g,
+  sht: /she/g,
+  kkk: /kke/g,
+  fgt: /fgu/g, // 'u' avoids introducing 'gey'
+  dyk: /dye/g,
+  bch: /bce/g
+};
+const REPLACEMENT_MAP_FORWARD = {
+  pre: /prn/g,
+  f4nne: /f4nny/g,
+  gtw4e: /tw4t/g,
+  ngu: /ngr/g, // 'u' avoids introducing 'gey'
+  dce: /dck/g,
+  vju: /vjn/g, // 'u' avoids introducing 'jew'
+  fce: /fck/g,
+  pne: /pns/g,
+  she: /sht/g,
+  kke: /kkk/g,
+  fgu: /fgt/g, // 'u' avoids introducing 'gey'
+  dye: /dyk/g,
+  bce: /bch/g
 };
 
 const FIRST_TUPLE_REGEX = `[${ALPHABET}${REPLACEMENT_CHARS}${PADDING_CHAR}]{3}`;
@@ -180,25 +198,14 @@ function stripEncoding(string) {
     .replace(PADDING_REGEX, '');
 }
 
-function replaceAll(haystack, needle, replacement) {
-  // This is a workaround for String.prototypel.replaceAll
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll
-
-  while (haystack.indexOf(needle) !== -1) {
-    haystack = haystack.replace(needle, replacement);
-  }
-
-  return haystack;
-}
-
 /**
  * Sanitize a placekey alphabet encoded string, removing potentially offensive letters
  * @param {string} string
  * @returns {string}
  */
 function cleanString(string) {
-  for (const [key, value] of Object.entries(REPLACEMENT_MAP)) {
-    string = replaceAll(string, key, value);
+  for (const [replacement, regexp] of Object.entries(REPLACEMENT_MAP_FORWARD)) {
+    string = string.replace(regexp, replacement);
   }
   return string;
 }
@@ -208,11 +215,11 @@ function cleanString(string) {
  * @param {string} string
  * @returns {string}
  */
-function dirtyString(s) {
-  for (const [key, value] of Object.entries(REPLACEMENT_MAP).reverse()) {
-    s = replaceAll(s, value, key);
+function dirtyString(string) {
+  for (const [replacement, regexp] of Object.entries(REPLACEMENT_MAP_BACKWARD).reverse()) {
+    string = string.replace(regexp, replacement);
   }
-  return s;
+  return string;
 }
 
 const DECODE_OFFSETS = [

--- a/src/lib/placekey.js
+++ b/src/lib/placekey.js
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import {h3ToGeo, geoToH3, h3ToGeoBoundary, h3Distance, degsToRads} from 'h3-js';
+import {h3ToGeo, geoToH3, h3ToGeoBoundary, degsToRads} from 'h3-js';
 
 import {
   h3IntegerToString,
@@ -180,6 +180,17 @@ function stripEncoding(string) {
     .replace(PADDING_REGEX, '');
 }
 
+function replaceAll(haystack, needle, replacement) {
+  // This is a workaround for String.prototypel.replaceAll
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll
+
+  while (haystack.indexOf(needle) !== -1) {
+    haystack = haystack.replace(needle, replacement);
+  }
+
+  return haystack;
+}
+
 /**
  * Sanitize a placekey alphabet encoded string, removing potentially offensive letters
  * @param {string} string
@@ -187,8 +198,7 @@ function stripEncoding(string) {
  */
 function cleanString(string) {
   for (const [key, value] of Object.entries(REPLACEMENT_MAP)) {
-    // TODO: May misencode due to JS replace/replaceAll
-    string = string.replace(key, value);
+    string = replaceAll(string, key, value);
   }
   return string;
 }
@@ -200,8 +210,7 @@ function cleanString(string) {
  */
 function dirtyString(s) {
   for (const [key, value] of Object.entries(REPLACEMENT_MAP).reverse()) {
-    // TODO: May misdecode due to JS replace/replaceAll
-    s = s.replace(value, key);
+    s = replaceAll(s, value, key);
   }
   return s;
 }

--- a/test/placekey.spec.js
+++ b/test/placekey.spec.js
@@ -36,6 +36,12 @@ test('stringCleaning', t => {
   t.end();
 });
 
+test('stringCleaningReplace', t => {
+  t.equal(_cleanString('prnprn'), 'prepre', 'clean bad words duplicated');
+  t.equal(_dirtyString('prepre'), 'prnprn', 'dirty bad words duplicated');
+  t.end();
+});
+
 test('placekeyIsValid', t => {
   t.ok(placekeyIsValid('abc-234-xyz'), 'where with no @');
   t.ok(placekeyIsValid('@abc-234-xyz'), 'where with @');


### PR DESCRIPTION
This accounts for a difference in Python and JavaScript replace functions. There is a built-in replaceAll function but it is not available in Node 12.