### PR TITLE
Update h3-js, use integer input, add benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A JavaScript library for working with [Placekeys](https://placekey.io).
 
-The source code for this library can be found [here](https://github.com/placekey/placekey-js/), and documentation for the Placekey service API can be found [here](https://docs.placekey.io/). The Plackey design specification is available [here](https://docs.placekey.io/Placekey_Technical_White_Paper.pdf). The details in Placekey encoding is [here](https://docs.placekey.io/Placekey_Encoding_Specification%20White_Paper.pdf). We welcome your feedback. 
+The source code for this library can be found [here](https://github.com/placekey/placekey-js/), and documentation for the Placekey service API can be found [here](https://docs.placekey.io/). The Plackey design specification is available [here](https://docs.placekey.io/Placekey_Technical_White_Paper.pdf). The details in Placekey encoding is [here](https://docs.placekey.io/Placekey_Encoding_Specification%20White_Paper.pdf). We welcome your feedback.
 
 To install:
 
@@ -69,6 +69,12 @@ To build and test:
 ```sh
 yarn bootstrap # install and build
 yarn test # run tests
+```
+
+To run benchmarks:
+
+```sh
+yarn bench
 ```
 
 PRs should include tests and, if necessary, documentation updates. To make sure non-trivial PRs will be accepted, consider opening an issue first and describe the changes you want to make before completing the work.

--- a/ocular-dev-tools.config.js
+++ b/ocular-dev-tools.config.js
@@ -1,5 +1,3 @@
-const {resolve} = require('path');
-
 const config = {
   lint: {
     paths: ['src', 'test', 'docs'],
@@ -10,7 +8,8 @@ const config = {
 
   entry: {
     test: 'test/node.js',
-    size: 'test/size.js'
+    size: 'test/size.js',
+    bench: 'test/bench/index.js'
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -26,16 +26,18 @@
     "cover": "npm run cover:node && npm run cover:browser && nyc report --reporter=lcov",
     "publish-prod": "ocular-publish prod",
     "publish-beta": "ocular-publish beta",
-    "test": "ocular-test"
+    "test": "ocular-test",
+    "bench": "ocular-test bench"
   },
   "pre-commit": [
     "test"
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "h3-js": "^3.6.3"
+    "h3-js": "^3.7.0"
   },
   "devDependencies": {
+    "@probe.gl/bench": "^3.3.0",
     "coveralls": "^3.0.0",
     "eslint-config-uber-jsx": "^3.0.0",
     "eslint-plugin-react": "~7.11.1",

--- a/src/lib/placekey.js
+++ b/src/lib/placekey.js
@@ -95,7 +95,7 @@ export function geoToPlacekey(lat, long) {
 
 // Convert a Placekey into a (latitude, longitude) tuple
 export function placekeyToGeo(placekey) {
-  return h3ToGeo(placekeyToH3(placekey));
+  return h3ToGeo(placekeyToH3Integer(placekey));
 }
 
 // Convert a Placekey string into an h3 string
@@ -110,7 +110,7 @@ export function h3ToPlacekey(h3index) {
 
 // Given a placekey, return the cooridnates of the boundary of the hexagon.
 export function placekeyToHexBoundary(placekey, formatAsGeoJson) {
-  return h3ToGeoBoundary(placekeyToH3(placekey), formatAsGeoJson);
+  return h3ToGeoBoundary(placekeyToH3Integer(placekey), formatAsGeoJson);
 }
 
 export function placekeyDistance(placekey1, placekey2) {

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -1,0 +1,5 @@
+// Enables ES2015 import/export in Node.js
+require('reify');
+
+// Run benchmarks
+require('./placekey.bench');

--- a/test/bench/placekey.bench.js
+++ b/test/bench/placekey.bench.js
@@ -1,0 +1,43 @@
+/**
+ * Light benchmark suite for placekey-js
+ */
+
+const {Bench} = require('@probe.gl/bench');
+
+import {
+  placekeyToGeo,
+  geoToPlacekey,
+  placekeyToHexBoundary,
+  placekeyIsValid
+} from '@placekey/placekey';
+import SAMPLES from '../data/example_geos.json';
+
+const suite = new Bench({
+  minIterations: 10
+});
+
+suite.add('geoToPlacekey (100 rows)', () => {
+  for (const row of SAMPLES) {
+    geoToPlacekey(row.lat, row.long);
+  }
+});
+
+suite.add('placekeyToGeo (100 rows)', () => {
+  for (const row of SAMPLES) {
+    placekeyToGeo(row.placekey);
+  }
+});
+
+suite.add('placekeyToHexBoundary (100 rows)', () => {
+  for (const row of SAMPLES) {
+    placekeyToHexBoundary(row.placekey);
+  }
+});
+
+suite.add('placekeyIsValid (100 rows)', () => {
+  for (const row of SAMPLES) {
+    placekeyIsValid(row.placekey);
+  }
+});
+
+suite.run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1735,6 +1735,21 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@probe.gl/bench@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@probe.gl/bench/-/bench-3.3.0.tgz#41184c2c6b95637b4fae9e8940bf4089be537dd9"
+  integrity sha512-nDg3sOIWIrQdDraGWlu8fHG3AF/jbXvTkQy08MvjPrJnINlq6QNFWyMo6Rkr48WCfgA3gbSrVv7SxqwDgy1v8g==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    probe.gl "3.3.0"
+
+"@probe.gl/stats@3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@probe.gl/stats/-/stats-3.3.0.tgz#66f684ead7cee1f2aad5ee5e9d297e84e08c5536"
+  integrity sha512-CV4c3EgallqZTO88u34/u9L5asL0nCVP1BEkb4qcXlh8Qz2Vmygbyjz1ViQsct6rSi2lJ52lo6W0PnlpZJJvcA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -4881,10 +4896,10 @@ gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-h3-js@^3.6.3:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-3.6.4.tgz#eb14f63a1fe1efec04194266271ec0af9c021566"
-  integrity sha512-wMu0Y+vdh4xx2WT1jqy4QDBgJupjBfHsGaMtMsFocdZdIsfxLFufzjGcmReOSfKQ+twRO2XjXAmDY9h1nq99EA==
+h3-js@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-3.7.0.tgz#f0ff5563ae04ce448cbe6b8573d9796a6c97f5ad"
+  integrity sha512-EcH/qGU4khZsAEG39Uu8MvaCing0JFcuoe3K4Xmg5MofDIu1cNJl7z2AQS8ggvXGxboiLJqsGirhEqFKdd2gAA==
 
 handle-thing@^2.0.0:
   version "2.0.1"
@@ -7525,6 +7540,14 @@ pretty-error@^2.0.2:
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
+
+probe.gl@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/probe.gl/-/probe.gl-3.3.0.tgz#a64e2f007d36a6262b12f3b1e99ca5dc3762b3c3"
+  integrity sha512-59E6AEw4N8sU4PKfAl7S2UBYJCOa064WpEFcXfeFOB/36FJtplYY+261DqLjLAvOqRRHiKVEQUBo63PQ3jKeWA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@probe.gl/stats" "3.3.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
- Updates `h3-js` to 3.7.0 to take advantage of the new integer input support
- Updates `placekeyToGeo` and `placekeyToHexBoundary` to skip the string encoding and pass the integer in directly
- Adds benchmarks, because any good performance optimization PR should demonstrate the actual benefit :)

The improvement here is modest, but present:

**Before**
```
Running bench tests...
├─ geoToPlacekey (100 rows): 1.74K /s ±0.53%
├─ placekeyToGeo (100 rows): 1.30K /s ±3.05%
├─ placekeyToHexBoundary (100 rows): 1.12K /s ±1.59%
├─ placekeyIsValid (100 rows): 33.8K /s ±0.46%
```

**After**
```
Running bench tests...
├─ geoToPlacekey (100 rows): 1.78K /s ±1.04%
├─ placekeyToGeo (100 rows): 1.60K /s ±1.37%
├─ placekeyToHexBoundary (100 rows): 1.34K /s ±1.11%
├─ placekeyIsValid (100 rows): 34.1K /s ±0.51%
```
So about 23% speedup for `placekeyToGeo` and 20% for `placekeyToHexBoundary`.